### PR TITLE
KE-4 Design Parent and Child Relationship 

### DIFF
--- a/app/Http/Controllers/AdultFamilyMemberController.php
+++ b/app/Http/Controllers/AdultFamilyMemberController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreAdultFamilyMemberRequest;
+use App\Http\Requests\UpdateAdultFamilyMemberRequest;
+use App\Models\AdultFamilyMember;
+
+class AdultFamilyMemberController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreAdultFamilyMemberRequest $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(AdultFamilyMember $adultFamilyMember)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(AdultFamilyMember $adultFamilyMember)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateAdultFamilyMemberRequest $request, AdultFamilyMember $adultFamilyMember)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(AdultFamilyMember $adultFamilyMember)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/ChildController.php
+++ b/app/Http/Controllers/ChildController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreChildRequest;
+use App\Http\Requests\UpdateChildRequest;
+use App\Models\Child;
+
+class ChildController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreChildRequest $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Child $child)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Child $child)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateChildRequest $request, Child $child)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Child $child)
+    {
+        //
+    }
+}

--- a/app/Http/Requests/StoreAdultFamilyMemberRequest.php
+++ b/app/Http/Requests/StoreAdultFamilyMemberRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreAdultFamilyMemberRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/StoreChildRequest.php
+++ b/app/Http/Requests/StoreChildRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\MaxChildrenRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreChildRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'first_name' => 'required|string|max:255',
+            'last_name' => 'required|string|max:255',
+            'dob' => 'required|date',
+            'adult_family_member_id' => [
+                'required',
+                'exists:adult_family_members,id',
+                new MaxChildrenRule($this->input('adult_family_member_id')), // Pass the parent ID to the rule
+            ],
+        ];       
+    }
+}

--- a/app/Http/Requests/UpdateAdultFamilyMemberRequest.php
+++ b/app/Http/Requests/UpdateAdultFamilyMemberRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateAdultFamilyMemberRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateChildRequest.php
+++ b/app/Http/Requests/UpdateChildRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateChildRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Models/AdultFamilyMember.php
+++ b/app/Models/AdultFamilyMember.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AdultFamilyMember extends Model
+{
+    /** @use HasFactory<\Database\Factories\AdultFamilyMemberFactory> */
+    use HasFactory;
+
+    public function user():BelongsTo
+{
+    return $this->belongsTo(User::class);
+}
+
+public function children():HasMany
+{
+    return $this->hasMany(Child::class);
+}
+}

--- a/app/Models/Child.php
+++ b/app/Models/Child.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Child extends Model
+{
+    /** @use HasFactory<\Database\Factories\ChildFactory> */
+    use HasFactory;
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
@@ -46,4 +47,9 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function adultFamilyMember():HasOne
+{
+    return $this->hasOne(AdultFamilyMember::class);
+}
 }

--- a/app/Policies/AdultFamilyMemberPolicy.php
+++ b/app/Policies/AdultFamilyMemberPolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\AdultFamilyMember;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class AdultFamilyMemberPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, AdultFamilyMember $adultFamilyMember): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, AdultFamilyMember $adultFamilyMember): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, AdultFamilyMember $adultFamilyMember): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, AdultFamilyMember $adultFamilyMember): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, AdultFamilyMember $adultFamilyMember): bool
+    {
+        return false;
+    }
+}

--- a/app/Policies/ChildPolicy.php
+++ b/app/Policies/ChildPolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Child;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class ChildPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Child $child): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Child $child): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Child $child): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Child $child): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Child $child): bool
+    {
+        return false;
+    }
+}

--- a/app/Rules/MaxChildrenRule.php
+++ b/app/Rules/MaxChildrenRule.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\AdultFamilyMember;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class MaxChildrenRule implements ValidationRule
+{
+    
+    protected $adultFamilyMemberId;
+
+    public function __construct($adultFamilyMemberId)
+    {
+        $this->adultFamilyMemberId = $adultFamilyMemberId;
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $adultFamilyMember = AdultFamilyMember::withCount('children')
+            ->find($this->adultFamilyMemberId);
+
+        if (!$adultFamilyMember || $adultFamilyMember->children_count >= 3) {
+            $fail('A parent cannot have more than 3 children.');
+        }
+    }
+}

--- a/database/factories/AdultFamilyMemberFactory.php
+++ b/database/factories/AdultFamilyMemberFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\AdultFamilyMember>
+ */
+class AdultFamilyMemberFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/ChildFactory.php
+++ b/database/factories/ChildFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Child>
+ */
+class ChildFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -13,7 +13,6 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');

--- a/database/migrations/2025_01_18_114503_create_adult_family_members_table.php
+++ b/database/migrations/2025_01_18_114503_create_adult_family_members_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('adult_family_members', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('phone_number')->nullable();
+            $table->string('address')->nullable();
+            $table->string('relationship_to_child')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('adult_family_members');
+    }
+};

--- a/database/migrations/2025_01_18_115026_create_children_table.php
+++ b/database/migrations/2025_01_18_115026_create_children_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('children', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('adult_family_member_id')->constrained('adult_family_members')->onDelete('cascade');
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->date('dob');
+            $table->string('gender')->nullable();
+            $table->string('enrollment_status')->default('pending'); // or enum
+            $table->foreignId('group_id')->nullable()->constrained('groups')->onDelete('set null');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('children');
+    }
+};

--- a/database/seeders/AdultFamilyMemberSeeder.php
+++ b/database/seeders/AdultFamilyMemberSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class AdultFamilyMemberSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}

--- a/database/seeders/ChildSeeder.php
+++ b/database/seeders/ChildSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class ChildSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
Design Parent and Child Relationship Adding a MaxChildRule and removed name from User Table.

Create children table:

Define fields: id, name, parent_id (foreign key), dob, and timestamps.

Add a foreign key constraint to parent_id.

Write the migration file for the children table.

Establish parent-child relationship:

Update models (User for parent and Child) to define hasMany and belongsTo relationships.

Validation for Parent Registration:

Implement a validation rule to restrict each parent to a maximum of 3 children.